### PR TITLE
Enumerate device nub. Fix crash when unloading w/ enumerated nubs. Add _CRS parser

### DIFF
--- a/VoodooI2C/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C/VoodooI2C.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		AC015C481F32345500516383 /* VoodooI2CACPIController.hpp in Headers */ = {isa = PBXBuildFile; fileRef = AC015C461F32345500516383 /* VoodooI2CACPIController.hpp */; };
 		AC0AD4581F3842800070A642 /* VoodooI2CDeviceNub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC0AD4561F3842800070A642 /* VoodooI2CDeviceNub.cpp */; };
 		AC0AD4591F3842800070A642 /* VoodooI2CDeviceNub.hpp in Headers */ = {isa = PBXBuildFile; fileRef = AC0AD4571F3842800070A642 /* VoodooI2CDeviceNub.hpp */; };
-		AC2603BE1F2F32BD00CF238F /* VoodooI2CController in Resources */ = {isa = PBXBuildFile; fileRef = AC2603BD1F2F32BD00CF238F /* VoodooI2CController */; };
 		AC4954511F31E91D0040E11F /* VoodooI2CPCIController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC49544F1F31E91D0040E11F /* VoodooI2CPCIController.cpp */; };
 		AC4954521F31E91D0040E11F /* VoodooI2CPCIController.hpp in Headers */ = {isa = PBXBuildFile; fileRef = AC4954501F31E91D0040E11F /* VoodooI2CPCIController.hpp */; };
 		AC6268941F2F6CF1000CBF2D /* VoodooI2CController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC6268921F2F6CF1000CBF2D /* VoodooI2CController.cpp */; };
@@ -23,6 +22,9 @@
 		ACF810E91F3304720031A6F5 /* VoodooI2CControllerNub.hpp in Headers */ = {isa = PBXBuildFile; fileRef = ACF810E71F3304720031A6F5 /* VoodooI2CControllerNub.hpp */; };
 		ACFCBA901F33644D00F9B59C /* VoodooI2CControllerDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ACFCBA8E1F33644D00F9B59C /* VoodooI2CControllerDriver.cpp */; };
 		ACFCBA911F33644D00F9B59C /* VoodooI2CControllerDriver.hpp in Headers */ = {isa = PBXBuildFile; fileRef = ACFCBA8F1F33644D00F9B59C /* VoodooI2CControllerDriver.hpp */; };
+		F1E57E121F4BC2EC00784765 /* linuxirq.h in Headers */ = {isa = PBXBuildFile; fileRef = F1E57E0F1F4BC2EC00784765 /* linuxirq.h */; };
+		F1E57E131F4BC2EC00784765 /* VoodooI2CACPICRSParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1E57E101F4BC2EC00784765 /* VoodooI2CACPICRSParser.cpp */; };
+		F1E57E141F4BC2EC00784765 /* VoodooI2CACPICRSParser.h in Headers */ = {isa = PBXBuildFile; fileRef = F1E57E111F4BC2EC00784765 /* VoodooI2CACPICRSParser.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,7 +35,6 @@
 		AC0AD4571F3842800070A642 /* VoodooI2CDeviceNub.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooI2CDeviceNub.hpp; path = VoodooI2CDevice/VoodooI2CDeviceNub.hpp; sourceTree = "<group>"; };
 		AC2603B01F2F294000CF238F /* VoodooI2C.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VoodooI2C.kext; sourceTree = BUILT_PRODUCTS_DIR; };
 		AC2603B71F2F294000CF238F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AC2603BD1F2F32BD00CF238F /* VoodooI2CController */ = {isa = PBXFileReference; lastKnownFileType = folder; name = VoodooI2CController; path = "/Volumes/OS X Data/Programming/opensource/VoodooI2C/VoodooI2C/VoodooI2C/VoodooI2CController"; sourceTree = "<absolute>"; };
 		AC49544F1F31E91D0040E11F /* VoodooI2CPCIController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VoodooI2CPCIController.cpp; path = VoodooI2CController/VoodooI2CPCIController.cpp; sourceTree = "<group>"; };
 		AC4954501F31E91D0040E11F /* VoodooI2CPCIController.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooI2CPCIController.hpp; path = VoodooI2CController/VoodooI2CPCIController.hpp; sourceTree = "<group>"; };
 		AC6268921F2F6CF1000CBF2D /* VoodooI2CController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VoodooI2CController.cpp; path = VoodooI2CController/VoodooI2CController.cpp; sourceTree = "<group>"; };
@@ -45,6 +46,9 @@
 		ACF810E71F3304720031A6F5 /* VoodooI2CControllerNub.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooI2CControllerNub.hpp; path = VoodooI2CController/VoodooI2CControllerNub.hpp; sourceTree = "<group>"; };
 		ACFCBA8E1F33644D00F9B59C /* VoodooI2CControllerDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VoodooI2CControllerDriver.cpp; path = VoodooI2CController/VoodooI2CControllerDriver.cpp; sourceTree = "<group>"; };
 		ACFCBA8F1F33644D00F9B59C /* VoodooI2CControllerDriver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooI2CControllerDriver.hpp; path = VoodooI2CController/VoodooI2CControllerDriver.hpp; sourceTree = "<group>"; };
+		F1E57E0F1F4BC2EC00784765 /* linuxirq.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = linuxirq.h; path = VoodooI2CACPICRSParser/linuxirq.h; sourceTree = "<group>"; };
+		F1E57E101F4BC2EC00784765 /* VoodooI2CACPICRSParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VoodooI2CACPICRSParser.cpp; path = VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.cpp; sourceTree = "<group>"; };
+		F1E57E111F4BC2EC00784765 /* VoodooI2CACPICRSParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = VoodooI2CACPICRSParser.h; path = VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +101,7 @@
 		AC6268901F2F6CB9000CBF2D /* VoodooI2C Core */ = {
 			isa = PBXGroup;
 			children = (
+				F1E57E0E1F4BC2D400784765 /* VoodooI2C ACPI Parser */,
 				AC0AD4551F38425A0070A642 /* VoodooI2C Device */,
 				AC6268911F2F6CDA000CBF2D /* VoodooI2C Controller */,
 			);
@@ -138,6 +143,16 @@
 			name = Miscellaneous;
 			sourceTree = "<group>";
 		};
+		F1E57E0E1F4BC2D400784765 /* VoodooI2C ACPI Parser */ = {
+			isa = PBXGroup;
+			children = (
+				F1E57E0F1F4BC2EC00784765 /* linuxirq.h */,
+				F1E57E101F4BC2EC00784765 /* VoodooI2CACPICRSParser.cpp */,
+				F1E57E111F4BC2EC00784765 /* VoodooI2CACPICRSParser.h */,
+			);
+			name = "VoodooI2C ACPI Parser";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -149,7 +164,9 @@
 				ACFCBA911F33644D00F9B59C /* VoodooI2CControllerDriver.hpp in Headers */,
 				AC4954521F31E91D0040E11F /* VoodooI2CPCIController.hpp in Headers */,
 				AC888F8C1F2F8155002C5F7B /* helpers.hpp in Headers */,
+				F1E57E121F4BC2EC00784765 /* linuxirq.h in Headers */,
 				AC0AD4591F3842800070A642 /* VoodooI2CDeviceNub.hpp in Headers */,
+				F1E57E141F4BC2EC00784765 /* VoodooI2CACPICRSParser.h in Headers */,
 				AC015C481F32345500516383 /* VoodooI2CACPIController.hpp in Headers */,
 				AC6268951F2F6CF1000CBF2D /* VoodooI2CController.hpp in Headers */,
 			);
@@ -215,7 +232,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AC2603BE1F2F32BD00CF238F /* VoodooI2CController in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,6 +277,7 @@
 				AC0AD4581F3842800070A642 /* VoodooI2CDeviceNub.cpp in Sources */,
 				ACF810E81F3304720031A6F5 /* VoodooI2CControllerNub.cpp in Sources */,
 				AC6268941F2F6CF1000CBF2D /* VoodooI2CController.cpp in Sources */,
+				F1E57E131F4BC2EC00784765 /* VoodooI2CACPICRSParser.cpp in Sources */,
 				AC015C471F32345500516383 /* VoodooI2CACPIController.cpp in Sources */,
 				AC888F8B1F2F8155002C5F7B /* helpers.cpp in Sources */,
 				ACFCBA901F33644D00F9B59C /* VoodooI2CControllerDriver.cpp in Sources */,
@@ -372,7 +389,7 @@
 				"OTHER_CPLUSPLUSFLAGS[arch=*]" = "-Wno-inconsistent-missing-override";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alexandred.VoodooI2C;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = kext;
 			};
 			name = Debug;
@@ -392,7 +409,7 @@
 				"OTHER_CPLUSPLUSFLAGS[arch=*]" = "-Wno-inconsistent-missing-override";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alexandred.VoodooI2C;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx10.10;
+				SDKROOT = macosx;
 				WRAPPER_EXTENSION = kext;
 			};
 			name = Release;

--- a/VoodooI2C/VoodooI2C/Info.plist
+++ b/VoodooI2C/VoodooI2C/Info.plist
@@ -17,7 +17,9 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2.0.0</string>
+	<key>OSBundleCompatibleVersion</key>
+	<string>2.0.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>VoodooI2CPCIController</key>

--- a/VoodooI2C/VoodooI2C/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.cpp
@@ -1,0 +1,184 @@
+//
+//  VoodooI2CACPICRSParser.cpp
+//  VoodooI2C
+//
+//  Created by CoolStar on 8/15/17.
+//  Copyright © 2017 CoolStar. All rights reserved.
+//
+
+// Demo Standalone Program: https://ghostbin.com/paste/tqt73
+
+#include "VoodooI2CACPICRSParser.h"
+#include <IOKit/IOLib.h>
+#include <string.h>
+#include "linuxirq.h"
+
+VoodooI2CACPICRSParser::VoodooI2CACPICRSParser(){
+    foundGPIOInt = false;
+    foundI2C = false;
+}
+
+void VoodooI2CACPICRSParser::parse_acpi_serialbus(uint8_t *crs, uint32_t offset, uint32_t sz){
+    if (foundI2C)
+        return;
+    if (offset >= sz)
+        return;
+    uint8_t opcode = crs[offset];
+    if (opcode != 0x8e)
+        return;
+    
+    uint16_t len;
+    memcpy(&len, crs + offset + 1, sizeof(uint16_t));
+    
+    uint8_t bustype = crs[offset + 5];
+    if (bustype != 1)
+        return; //Only support I2C. Bus type 2 = SPI, 3 = UART
+    
+    uint8_t flags = crs[offset + 6];
+    
+    uint16_t tflags;
+    memcpy(&tflags, crs + offset + 7, sizeof(uint16_t));
+    
+    /*uint16_t datalen;
+    memcpy(&datalen, crs + offset + 10, sizeof(uint16_t));*/
+    
+    if (bustype == 1){
+        foundI2C = true;
+        
+        i2cInfo.resourceConsumer = (flags >> 1) & 0x1;
+        i2cInfo.deviceInitiated = flags & 0x1;
+        i2cInfo.addressMode10Bit = tflags & 0x1;
+        
+        uint32_t busspeed;
+        memcpy(&busspeed, crs + offset + 12, sizeof(uint32_t));
+        i2cInfo.busSpeed = busspeed;
+        
+        uint16_t address;
+        memcpy(&address, crs + offset + 16, sizeof(uint16_t));
+        i2cInfo.address = address;
+        
+        /*uint8_t i2cLen = len - (12 + datalen - 3);
+        
+        char *i2cBus = (char *)malloc(i2cLen);
+        memcpy(i2cBus, crs + offset + 12 + datalen, i2cLen);
+        IOLog("I2C Bus: %s\n", i2cBus);*/
+    }
+}
+
+void VoodooI2CACPICRSParser::parse_acpi_gpio(uint8_t *crs, uint32_t offset, uint32_t sz){
+    if (foundGPIOInt)
+        return;
+    if (offset >= sz)
+        return;
+    
+    uint8_t opcode = crs[offset];
+    if (opcode != 0x8c)
+        return;
+    
+    uint16_t len;
+    memcpy(&len, crs + offset + 1, sizeof(uint16_t));
+    
+    uint8_t gpiotype = crs[offset + 4];
+    uint8_t flags = crs[offset + 5];
+    
+    uint8_t gpioFlags = crs[offset + 7];
+    
+    uint8_t pinConfig = crs[offset + 9];
+    
+    uint16_t pinOffset;
+    memcpy(&pinOffset, crs + offset + 14, sizeof(uint16_t));
+    
+    /*uint16_t resourceOffset;
+    memcpy(&resourceOffset, crs + offset + 17, sizeof(uint16_t));
+    
+    uint16_t vendorOffset;
+    memcpy(&vendorOffset, crs + offset + 19, sizeof(uint16_t));*/
+    
+    uint16_t pinNumber;
+    memcpy(&pinNumber, crs + offset + pinOffset, sizeof(uint16_t));
+    
+    if (pinNumber == 0xFFFF) //pinNumber 0xFFFF is invalid
+        return;
+    
+    /*char *gpioController = (char *)malloc(vendorOffset - resourceOffset);
+    memcpy(gpioController, crs + offset + resourceOffset, vendorOffset - resourceOffset);
+    IOLog("GPIO Controller: %s\n", gpioController);*/
+    
+    if (gpiotype == 0){
+        //GPIOInt
+        
+        foundGPIOInt = true;
+        
+        gpioInt.resourceConsumer = flags & 0x1;
+        gpioInt.levelInterrupt = !(gpioFlags & 0x1);
+        
+        gpioInt.interruptPolarity = (gpioFlags >> 1) & 0x3;
+        
+        gpioInt.sharedInterrupt = (gpioFlags >> 3) & 0x1;
+        gpioInt.wakeInterrupt = (gpioFlags >> 4) & 0x1;
+        
+        gpioInt.pinConfig = pinConfig;
+        gpioInt.pinNumber = pinNumber;
+        
+        int irq = 0;
+        if (gpioInt.levelInterrupt){
+            switch (gpioInt.interruptPolarity){
+                case 0:
+                    irq = IRQ_TYPE_LEVEL_HIGH;
+                    break;
+                case 1:
+                    irq = IRQ_TYPE_LEVEL_LOW;
+                    break;
+                default:
+                    irq = IRQ_TYPE_LEVEL_LOW;
+                    break;
+            }
+        } else {
+            switch (gpioInt.interruptPolarity) {
+                case 0:
+                    irq = IRQ_TYPE_EDGE_FALLING;
+                    break;
+                case 1:
+                    irq = IRQ_TYPE_EDGE_RISING;
+                    break;
+                case 2:
+                    irq = IRQ_TYPE_EDGE_BOTH;
+                default:
+                    irq = IRQ_TYPE_EDGE_FALLING;
+                    break;
+            }
+        }
+        gpioInt.irqType = irq;
+    }
+    
+    if (gpiotype == 1){
+        //GPIOIo
+        
+        foundGPIOIO = true;
+        
+        gpioIO.resourceConsumer = flags & 0x1;
+        gpioIO.ioRestriction = gpioFlags & 0x3;
+        gpioIO.sharing = (gpioFlags >> 3) & 0x1;
+        
+        gpioIO.pinConfig = pinConfig;
+        gpioIO.pinNumber = pinNumber;
+    }
+}
+
+void VoodooI2CACPICRSParser::parse_acpi_crs(uint8_t *crs, uint32_t offset, uint32_t sz){
+    if (offset >= sz)
+        return;
+    
+    uint8_t opcode = crs[offset];
+    
+    uint16_t len;
+    memcpy(&len, crs + offset + 1, sizeof(uint16_t));
+    
+    if (opcode == 0x8c)
+        parse_acpi_gpio(crs, offset, sz);
+    if (opcode == 0x8e)
+        parse_acpi_serialbus(crs, offset, sz);
+    
+    offset += (len + 3);
+    parse_acpi_crs(crs, offset, sz);
+}

--- a/VoodooI2C/VoodooI2C/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.h
+++ b/VoodooI2C/VoodooI2C/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.h
@@ -1,0 +1,64 @@
+//
+//  VoodooI2CACPICRSParser.hpp
+//  VoodooI2C
+//
+//  Created by CoolStar on 8/15/17.
+//  Copyright © 2017 CoolStar. All rights reserved.
+//
+
+#include <stdint.h>
+
+#ifndef VoodooI2CACPICRSParser_h
+#define VoodooI2CACPICRSParser_h
+
+struct i2c_info {
+    bool resourceConsumer;
+    bool deviceInitiated;
+    bool addressMode10Bit;
+    
+    uint32_t busSpeed;
+    uint16_t address;
+};
+
+struct gpio_int_info {
+    bool resourceConsumer;
+    bool levelInterrupt;
+    
+    uint8_t interruptPolarity;
+    
+    bool sharedInterrupt;
+    bool wakeInterrupt;
+    
+    uint8_t pinConfig;
+    uint16_t pinNumber;
+    
+    int irqType;
+};
+
+struct gpio_io_info {
+    bool resourceConsumer;
+    uint8_t ioRestriction;
+    bool sharing;
+    
+    uint8_t pinConfig;
+    uint16_t pinNumber;
+};
+
+class VoodooI2CACPICRSParser {
+public:
+    bool foundI2C;
+    bool foundGPIOInt;
+    bool foundGPIOIO;
+    
+    i2c_info i2cInfo;
+    gpio_int_info gpioInt;
+    gpio_io_info gpioIO;
+    
+    VoodooI2CACPICRSParser();
+    void parse_acpi_crs(uint8_t *crs, uint32_t offset, uint32_t sz);
+private:
+    void parse_acpi_serialbus(uint8_t *crs, uint32_t offset, uint32_t sz);
+    void parse_acpi_gpio(uint8_t *crs, uint32_t offset, uint32_t sz);
+};
+
+#endif /* VoodooI2CACPICRSParser_h */

--- a/VoodooI2C/VoodooI2C/VoodooI2CACPICRSParser/linuxirq.h
+++ b/VoodooI2C/VoodooI2C/VoodooI2CACPICRSParser/linuxirq.h
@@ -1,0 +1,39 @@
+//
+//  linuxirq.h
+//  VoodooGPIO
+//
+//  Created by CoolStar on 8/14/17.
+//  Copyright © 2017 CoolStar. All rights reserved.
+//
+
+#ifndef linuxirq_h
+#define linuxirq_h
+
+enum {
+    IRQ_TYPE_NONE		= 0x00000000,
+    IRQ_TYPE_EDGE_RISING	= 0x00000001,
+    IRQ_TYPE_EDGE_FALLING	= 0x00000002,
+    IRQ_TYPE_EDGE_BOTH	= (IRQ_TYPE_EDGE_FALLING | IRQ_TYPE_EDGE_RISING),
+    IRQ_TYPE_LEVEL_HIGH	= 0x00000004,
+    IRQ_TYPE_LEVEL_LOW	= 0x00000008,
+    IRQ_TYPE_LEVEL_MASK	= (IRQ_TYPE_LEVEL_LOW | IRQ_TYPE_LEVEL_HIGH),
+    IRQ_TYPE_SENSE_MASK	= 0x0000000f,
+    IRQ_TYPE_DEFAULT	= IRQ_TYPE_SENSE_MASK,
+    
+    IRQ_TYPE_PROBE		= 0x00000010,
+    
+    IRQ_LEVEL		= (1 <<  8),
+    IRQ_PER_CPU		= (1 <<  9),
+    IRQ_NOPROBE		= (1 << 10),
+    IRQ_NOREQUEST		= (1 << 11),
+    IRQ_NOAUTOEN		= (1 << 12),
+    IRQ_NO_BALANCING	= (1 << 13),
+    IRQ_MOVE_PCNTXT		= (1 << 14),
+    IRQ_NESTED_THREAD	= (1 << 15),
+    IRQ_NOTHREAD		= (1 << 16),
+    IRQ_PER_CPU_DEVID	= (1 << 17),
+    IRQ_IS_POLLED		= (1 << 18),
+    IRQ_DISABLE_UNLAZY	= (1 << 19),
+};
+
+#endif /* linuxirq_h */

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CController.cpp
@@ -134,7 +134,7 @@ void VoodooI2CController::releaseResources() {
     if (physical_device) {
         if (nub) {
             nub->detach(this);
-            OSSafeRelease(nub);
+            OSSafeReleaseNULL(nub);
         }
 
         if (physical_device->mmap) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -291,7 +291,8 @@ IOReturn VoodooI2CControllerDriver::publishNubs() {
                     VoodooI2CDeviceNub* device_nub = OSTypeAlloc(VoodooI2CDeviceNub);
 
                     if (!device_nub->init(child->dictionaryWithProperties()) ||
-                        !device_nub->attach(this, child)) {
+                        !device_nub->attach(this, child) ||
+                        !device_nub->start(this)) {
                         IOLog("%s::%s Could not initialise nub for %s\n", getName(), bus_device->name, getMatchedName(child));
                         OSSafeReleaseNULL(device_nub);
                         continue;

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -79,6 +79,7 @@ class VoodooI2CControllerDriver : public IOService {
     void handleInterrupt();
     bool init(OSDictionary* properties);
     VoodooI2CControllerDriver* probe(IOService* provider, SInt32* score);
+    IOReturn transferI2C(VoodooI2CControllerBusMessage* messages, int number);
     bool start(IOService* provider);
     void stop(IOService* provider);
 
@@ -95,7 +96,6 @@ class VoodooI2CControllerDriver : public IOService {
     IOReturn toggleBusState(VoodooI2CState enabled);
     inline void toggleClockGating(VoodooI2CState enabled);
     void toggleInterrupts(VoodooI2CState enabled);
-    IOReturn transferI2C(VoodooI2CControllerBusMessage* messages, int number);
     IOReturn transferI2CGated(VoodooI2CControllerBusMessage* messages, int* number);
     void transferMessageToBus();
     IOReturn waitBusNotBusyI2C();

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -76,7 +76,7 @@ class VoodooI2CControllerDriver : public IOService {
     // function members
 
     void free();
-    void handleInterrupt();
+    void handleInterrupt(OSObject* owner, IOInterruptEventSource* src, int intCount);
     bool init(OSDictionary* properties);
     VoodooI2CControllerDriver* probe(IOService* provider, SInt32* score);
     IOReturn transferI2C(VoodooI2CControllerBusMessage* messages, int number);
@@ -84,6 +84,10 @@ class VoodooI2CControllerDriver : public IOService {
     void stop(IOService* provider);
 
  private:
+    IOCommandGate* command_gate;
+    IOInterruptEventSource* interrupt_source;
+    IOWorkLoop* work_loop;
+    
     IOReturn getBusConfig();
     void handleAbortI2C();
     IOReturn initialiseBus();
@@ -99,6 +103,8 @@ class VoodooI2CControllerDriver : public IOService {
     IOReturn transferI2CGated(VoodooI2CControllerBusMessage* messages, int* number);
     void transferMessageToBus();
     IOReturn waitBusNotBusyI2C();
+    
+    void releaseResources();
 };
 
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerNub.hpp
@@ -27,9 +27,6 @@ class VoodooI2CControllerNub : public IOService {
     VoodooI2CController* controller;
     VoodooI2CControllerDriver* driver;
     const char* name;
-    IOCommandGate* command_gate;
-    IOInterruptEventSource* interrupt_source;
-    IOWorkLoop* work_loop;
 
     // function members
 
@@ -40,10 +37,16 @@ class VoodooI2CControllerNub : public IOService {
     bool start(IOService* provider);
     void stop(IOService* provider);
     void writeRegister(UInt32 value, int offset);
+    
+    virtual IOReturn getInterruptType(int source, int *interruptType) override;
+    virtual IOReturn registerInterrupt(int source, OSObject *target, IOInterruptAction handler, void *refcon) override;
+    virtual IOReturn unregisterInterrupt(int source) override;
+    
+    virtual IOReturn enableInterrupt(int source) override;
+    virtual IOReturn disableInterrupt(int source) override;
 
  private:
     void interruptOccured(OSObject* owner, IOInterruptEventSource* src, int intCount);
-    void releaseResources();
 };
 
 #endif /* VoodooI2CControllerNub_hpp */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -80,6 +80,8 @@ bool VoodooI2CDeviceNub::start(IOService* provider) {
     if (!super::start(provider))
         return false;
     
+    IOLog("%s::Starting!\n", getName());
+    
     registerService();
 
     return true;

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -23,8 +23,6 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
     if (!super::attach(provider))
         return false;
 
-    child->attach(this);
-
     return true;
 }
 
@@ -72,6 +70,8 @@ void VoodooI2CDeviceNub::free() {
 bool VoodooI2CDeviceNub::start(IOService* provider) {
     if (!super::start(provider))
         return false;
+    
+    registerService();
 
     return true;
 }
@@ -83,5 +83,6 @@ bool VoodooI2CDeviceNub::start(IOService* provider) {
  */
 
 void VoodooI2CDeviceNub::stop(IOService* provider) {
+    IOLog("%s::Stopping!\n", getName());
     super::stop(provider);
 }

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -12,6 +12,7 @@
 #include <IOKit/IOLib.h>
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/IOService.h>
+#include <IOKit/acpi/IOACPIPlatformDevice.h>
 
 class VoodooI2CDeviceNub : public IOService {
   OSDeclareDefaultStructors(VoodooI2CDeviceNub);
@@ -29,6 +30,8 @@ class VoodooI2CDeviceNub : public IOService {
 
  protected:
  private:
+    IOACPIPlatformDevice *acpi_device;
+    bool get_device_resources();
 };
 
 


### PR DESCRIPTION
Enumerate the device nubs. Don't attach the ACPI device to the nub as the official Apple LPSS kexts don't do that.