### PR TITLE
Add support for APIC and GPIO interrupt handling on the device nub

### DIFF
--- a/Miscellaneous/VoodooI2CACPICRSParser/VoodooGPIO.hpp
+++ b/Miscellaneous/VoodooI2CACPICRSParser/VoodooGPIO.hpp
@@ -1,0 +1,248 @@
+//
+//  VoodooGPIO.h
+//  VoodooGPIO
+//
+//  Created by CoolStar on 8/14/17.
+//  Copyright © 2017 CoolStar. All rights reserved.
+//
+
+#include <IOKit/IOLib.h>
+#include <IOKit/IOKitKeys.h>
+#include <IOKit/acpi/IOACPIPlatformDevice.h>
+#include <IOKit/IOWorkLoop.h>
+#include <IOKit/IOInterruptEventSource.h>
+#include <IOKit/IOLocks.h>
+#include <IOKit/IOCommandGate.h>
+#include "linuxirq.hpp"
+
+#ifndef VoodooGPIO_h
+#define VoodooGPIO_h
+
+struct pinctrl_pin_desc {
+    unsigned number;
+    char *name;
+    void *drv_data;
+};
+
+#define PINCTRL_PIN(a, b) {.number = a, .name = b}
+#define PINCTRL_PIN_ANON(a) {.number = a}
+
+/**
+ * struct intel_pingroup - Description about group of pins
+ * @name: Name of the groups
+ * @pins: All pins in this group
+ * @npins: Number of pins in this groups
+ * @mode: Native mode in which the group is muxed out @pins. Used if @modes
+ *        is %NULL.
+ * @modes: If not %NULL this will hold mode for each pin in @pins
+ */
+struct intel_pingroup {
+    char *name;
+    unsigned *pins;
+    size_t npins;
+    unsigned short mode;
+    unsigned *modes;
+};
+
+/**
+ * struct intel_function - Description about a function
+ * @name: Name of the function
+ * @groups: An array of groups for this function
+ * @ngroups: Number of groups in @groups
+ */
+struct intel_function {
+    char *name;
+    char * const *groups;
+    size_t ngroups;
+};
+
+/**
+ * struct intel_padgroup - Hardware pad group information
+ * @reg_num: GPI_IS register number
+ * @base: Starting pin of this group
+ * @size: Size of this group (maximum is 32).
+ * @padown_num: PAD_OWN register number (assigned by the core driver)
+ *
+ * If pad groups of a community are not the same size, use this structure
+ * to specify them.
+ */
+struct intel_padgroup {
+    unsigned reg_num;
+    unsigned base;
+    unsigned size;
+    unsigned padown_num;
+};
+
+/**
+ * struct intel_community - Intel pin community description
+ * @barno: MMIO BAR number where registers for this community reside
+ * @padown_offset: Register offset of PAD_OWN register from @regs. If %0
+ *                 then there is no support for owner.
+ * @padcfglock_offset: Register offset of PADCFGLOCK from @regs. If %0 then
+ *                     locking is not supported.
+ * @hostown_offset: Register offset of HOSTSW_OWN from @regs. If %0 then it
+ *                  is assumed that the host owns the pin (rather than
+ *                  ACPI).
+ * @ie_offset: Register offset of GPI_IE from @regs.
+ * @pin_base: Starting pin of pins in this community
+ * @gpp_size: Maximum number of pads in each group, such as PADCFGLOCK,
+ *            HOSTSW_OWN,  GPI_IS, GPI_IE, etc. Used when @gpps is %NULL.
+ * @gpp_num_padown_regs: Number of pad registers each pad group consumes at
+ *			 minimum. Use %0 if the number of registers can be
+ *			 determined by the size of the group.
+ * @npins: Number of pins in this community
+ * @features: Additional features supported by the hardware
+ * @gpps: Pad groups if the controller has variable size pad groups
+ * @ngpps: Number of pad groups in this community
+ * @regs: Community specific common registers (reserved for core driver)
+ * @pad_regs: Community specific pad registers (reserved for core driver)
+ *
+ * Most Intel GPIO host controllers this driver supports each pad group is
+ * of equal size (except the last one). In that case the driver can just
+ * fill in @gpp_size field and let the core driver to handle the rest. If
+ * the controller has pad groups of variable size the client driver can
+ * pass custom @gpps and @ngpps instead.
+ */
+struct intel_community {
+    unsigned barno;
+    unsigned padown_offset;
+    unsigned padcfglock_offset;
+    unsigned hostown_offset;
+    unsigned ie_offset;
+    unsigned pin_base;
+    unsigned gpp_size;
+    unsigned gpp_num_padown_regs;
+    size_t npins;
+    unsigned features;
+    const struct intel_padgroup *gpps;
+    size_t ngpps;
+    bool gpps_alloc;
+    /* Reserved for the core driver */
+    IOMemoryMap *mmap;
+    IOVirtualAddress regs;
+    IOVirtualAddress pad_regs;
+    
+    unsigned *interruptTypes;
+    OSObject **pinInterruptActionOwners;
+    IOInterruptAction *pinInterruptAction;
+    void **pinInterruptRefcons;
+};
+
+struct intel_pad_context {
+    uint32_t padcfg0;
+    uint32_t padcfg1;
+    uint32_t padcfg2;
+};
+
+struct intel_community_context {
+    uint32_t *intmask;
+};
+
+struct intel_pinctrl_context {
+    struct intel_pad_context *pads;
+    struct intel_community_context *communities;
+};
+
+/* Additional features supported by the hardware */
+#define PINCTRL_FEATURE_DEBOUNCE	1
+#define PINCTRL_FEATURE_1K_PD		2
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
+/**
+ * PIN_GROUP - Declare a pin group
+ * @n: Name of the group
+ * @p: An array of pins this group consists
+ * @m: Mode which the pins are put when this group is active. Can be either
+ *     a single integer or an array of integers in which case mode is per
+ *     pin.
+ */
+#define PIN_GROUP(n, p, m)					\
+{							\
+.name = (n),					\
+.pins = (p),					\
+.npins = ARRAY_SIZE((p)),			\
+.mode = __builtin_choose_expr(			\
+__builtin_constant_p((m)), (m), 0),	\
+.modes = __builtin_choose_expr(			\
+__builtin_constant_p((m)), NULL, (m)),	\
+}
+
+#define FUNCTION(n, g)				\
+{					\
+.name = (n),			\
+.groups = (g),			\
+.ngroups = ARRAY_SIZE((g)),	\
+}
+
+class VoodooGPIO : public IOService {
+    OSDeclareDefaultStructors(VoodooGPIO);
+protected:
+    struct pinctrl_pin_desc *pins;
+    size_t npins;
+    const struct intel_pingroup *groups;
+    size_t ngroups;
+    struct intel_function *functions;
+    size_t nfunctions;
+    struct intel_community *communities;
+    size_t ncommunities;
+private:
+    struct intel_pinctrl_context context;
+    
+    bool controllerIsAwake;
+    
+    IOWorkLoop *workLoop;
+    IOInterruptEventSource *interruptSource;
+    IOInterruptEventSource *demoInterruptSource;
+    
+    UInt32 readl(IOVirtualAddress addr);
+    void writel(UInt32 b, IOVirtualAddress addr);
+    
+    struct intel_community *intel_get_community(unsigned pin);
+    const struct intel_padgroup *intel_community_get_padgroup(const struct intel_community *community, unsigned pin);
+    IOVirtualAddress intel_get_padcfg(unsigned pin, unsigned reg);
+    
+    bool intel_pad_owned_by_host(unsigned pin);
+    bool intel_pad_acpi_mode(unsigned pin);
+    bool intel_pad_locked(unsigned pin);
+    
+    void intel_gpio_irq_enable(unsigned pin);
+    void intel_gpio_irq_mask_unmask(unsigned pin, bool mask);
+    bool intel_gpio_irq_set_type(unsigned pin, unsigned type);
+    
+    bool intel_pinctrl_add_padgroups(intel_community *community);
+    
+    bool intel_pinctrl_should_save(unsigned pin);
+    void intel_pinctrl_pm_init();
+    void intel_pinctrl_pm_release();
+    void intel_pinctrl_suspend();
+    void intel_gpio_irq_init();
+    void intel_pinctrl_resume();
+    
+    void intel_gpio_community_irq_handler(struct intel_community *community);
+    
+    void InterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount);
+    
+    void TouchpadInterruptOccurred(OSObject *owner, IOInterruptEventSource *src, int intCount);
+    
+public:
+    
+    //IOInterruptEventSource *interruptForPin(unsigned pin, unsigned type, OSObject *owner, IOInterruptEventSource::Action action);
+    //bool deregisterInterrupt(unsigned pin);
+    
+    virtual IOReturn getInterruptType(int pin, int *interruptType) override;
+    virtual IOReturn registerInterrupt(int pin, OSObject *target, IOInterruptAction handler, void *refcon) override;
+    virtual IOReturn unregisterInterrupt(int pin) override;
+    
+    virtual IOReturn enableInterrupt(int pin) override;
+    virtual IOReturn disableInterrupt(int pin) override;
+    
+    IOReturn setInterruptTypeForPin(int pin, int type);
+    
+    virtual bool start(IOService *provider) override;
+    virtual void stop(IOService *provider) override;
+    
+    virtual IOReturn setPowerState(unsigned long powerState, IOService *whatDevice) override;
+};
+
+#endif /* VoodooGPIO_h */

--- a/VoodooI2C/VoodooI2C.xcodeproj/project.pbxproj
+++ b/VoodooI2C/VoodooI2C.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		ACF810E91F3304720031A6F5 /* VoodooI2CControllerNub.hpp in Headers */ = {isa = PBXBuildFile; fileRef = ACF810E71F3304720031A6F5 /* VoodooI2CControllerNub.hpp */; };
 		ACFCBA901F33644D00F9B59C /* VoodooI2CControllerDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ACFCBA8E1F33644D00F9B59C /* VoodooI2CControllerDriver.cpp */; };
 		ACFCBA911F33644D00F9B59C /* VoodooI2CControllerDriver.hpp in Headers */ = {isa = PBXBuildFile; fileRef = ACFCBA8F1F33644D00F9B59C /* VoodooI2CControllerDriver.hpp */; };
+		F14008B51F4E22FA0073EC49 /* VoodooGPIO.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F14008B41F4E22FA0073EC49 /* VoodooGPIO.hpp */; };
 		F1C8F7101F4E0ABE00B0C2B5 /* VoodooI2CController in Resources */ = {isa = PBXBuildFile; fileRef = F1C8F70F1F4E0ABE00B0C2B5 /* VoodooI2CController */; };
 /* End PBXBuildFile section */
 
@@ -50,6 +51,7 @@
 		ACF810E71F3304720031A6F5 /* VoodooI2CControllerNub.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooI2CControllerNub.hpp; path = VoodooI2CController/VoodooI2CControllerNub.hpp; sourceTree = "<group>"; };
 		ACFCBA8E1F33644D00F9B59C /* VoodooI2CControllerDriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = VoodooI2CControllerDriver.cpp; path = VoodooI2CController/VoodooI2CControllerDriver.cpp; sourceTree = "<group>"; };
 		ACFCBA8F1F33644D00F9B59C /* VoodooI2CControllerDriver.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooI2CControllerDriver.hpp; path = VoodooI2CController/VoodooI2CControllerDriver.hpp; sourceTree = "<group>"; };
+		F14008B41F4E22FA0073EC49 /* VoodooGPIO.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = VoodooGPIO.hpp; path = ../../Miscellaneous/VoodooI2CACPICRSParser/VoodooGPIO.hpp; sourceTree = "<group>"; };
 		F1C8F70F1F4E0ABE00B0C2B5 /* VoodooI2CController */ = {isa = PBXFileReference; lastKnownFileType = folder; name = VoodooI2CController; path = VoodooI2C/VoodooI2CController; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -67,6 +69,7 @@
 		AC02603F1F4D769B00901204 /* VoodooI2CCRSParser */ = {
 			isa = PBXGroup;
 			children = (
+				F14008B41F4E22FA0073EC49 /* VoodooGPIO.hpp */,
 				AC0260401F4D76B200901204 /* linuxirq.hpp */,
 				AC0260411F4D76B200901204 /* VoodooI2CACPICRSParser.cpp */,
 				AC0260421F4D76B200901204 /* VoodooI2CACPICRSParser.hpp */,
@@ -165,6 +168,7 @@
 			files = (
 				ACF810E91F3304720031A6F5 /* VoodooI2CControllerNub.hpp in Headers */,
 				ACFCBA911F33644D00F9B59C /* VoodooI2CControllerDriver.hpp in Headers */,
+				F14008B51F4E22FA0073EC49 /* VoodooGPIO.hpp in Headers */,
 				AC4954521F31E91D0040E11F /* VoodooI2CPCIController.hpp in Headers */,
 				AC888F8C1F2F8155002C5F7B /* helpers.hpp in Headers */,
 				AC0AD4591F3842800070A642 /* VoodooI2CDeviceNub.hpp in Headers */,

--- a/VoodooI2C/VoodooI2C/Info.plist
+++ b/VoodooI2C/VoodooI2C/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
-    <string>2.0.0</string>
-    <key>OSBundleCompatibleVersion</key>
-    <string>2.0.0</string>
+	<string>2.0.0</string>
+	<key>OSBundleCompatibleVersion</key>
+	<string>2.0.0</string>
 	<key>IOKitPersonalities</key>
 	<dict>
 		<key>VoodooI2CPCIController</key>
@@ -41,50 +41,52 @@
 			<key>IOProviderClass</key>
 			<string>IOService</string>
 		</dict>
-        <key>VoodooI2CACPIController</key>
-        <dict>
-            <key>IOClass</key>
-            <string>VoodooI2CACPIController</string>
-            <key>CFBundleIdentifier</key>
-            <string>com.alexandred.VoodooI2C</string>
-            <key>IONameMatch</key>
-            <array>
-                <string>INT33C2</string>
-                <string>INT33C3</string>
-                <string>INT3432</string>
-                <string>INT3433</string>
-            </array>
-            <key>IOProbeScore</key>
-            <integer>9999</integer>
-            <key>IOProviderClass</key>
-            <string>IOService</string>
-        </dict>
-        <key>VoodooI2CControllerDriver</key>
-        <dict>
-            <key>IOClass</key>
-            <string>VoodooI2CControllerDriver</string>
-            <key>CFBundleIdentifier</key>
-            <string>com.alexandred.VoodooI2C</string>
-            <key>IOProbeScore</key>
-            <integer>9999</integer>
-            <key>IOProviderClass</key>
-            <string>VoodooI2CControllerNub</string>
-        </dict>
+		<key>VoodooI2CACPIController</key>
+		<dict>
+			<key>IOClass</key>
+			<string>VoodooI2CACPIController</string>
+			<key>CFBundleIdentifier</key>
+			<string>com.alexandred.VoodooI2C</string>
+			<key>IONameMatch</key>
+			<array>
+				<string>INT33C2</string>
+				<string>INT33C3</string>
+				<string>INT3432</string>
+				<string>INT3433</string>
+			</array>
+			<key>IOProbeScore</key>
+			<integer>9999</integer>
+			<key>IOProviderClass</key>
+			<string>IOService</string>
+		</dict>
+		<key>VoodooI2CControllerDriver</key>
+		<dict>
+			<key>IOClass</key>
+			<string>VoodooI2CControllerDriver</string>
+			<key>CFBundleIdentifier</key>
+			<string>com.alexandred.VoodooI2C</string>
+			<key>IOProbeScore</key>
+			<integer>9999</integer>
+			<key>IOProviderClass</key>
+			<string>VoodooI2CControllerNub</string>
+		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2017 Alexandre Daoud. All rights reserved.</string>
-    <key>OSBundleLibraries</key>
-    <dict>
-        <key>com.apple.iokit.IOACPIFamily</key>
-        <string>1.4</string>
-        <key>com.apple.iokit.IOPCIFamily</key>
-        <string>2.9</string>
-        <key>com.apple.kpi.iokit</key>
-        <string>15.6</string>
-        <key>com.apple.kpi.libkern</key>
-        <string>15.6</string>
-        <key>com.apple.kpi.mach</key>
-        <string>15.6</string>
-    </dict>
+	<key>OSBundleLibraries</key>
+	<dict>
+		<key>com.apple.iokit.IOACPIFamily</key>
+		<string>1.4</string>
+		<key>com.apple.iokit.IOPCIFamily</key>
+		<string>2.9</string>
+		<key>com.apple.kpi.iokit</key>
+		<string>15.6</string>
+		<key>com.apple.kpi.libkern</key>
+		<string>15.6</string>
+		<key>com.apple.kpi.mach</key>
+		<string>15.6</string>
+		<key>org.coolstar.VoodooGPIO</key>
+		<string>1.1</string>
+	</dict>
 </dict>
 </plist>

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -13,6 +13,7 @@
 #include <IOKit/IOKitKeys.h>
 #include <IOKit/IOService.h>
 #include <IOKit/acpi/IOACPIPlatformDevice.h>
+#include "VoodooGPIO.hpp"
 
 class VoodooI2CDeviceNub : public IOService {
   OSDeclareDefaultStructors(VoodooI2CDeviceNub);
@@ -27,11 +28,24 @@ class VoodooI2CDeviceNub : public IOService {
     void free();
     bool start(IOService* provider);
     void stop(IOService* provider);
-
+    
+    virtual IOReturn disableInterrupt(int source) override;
+    virtual IOReturn enableInterrupt(int source) override;
+    virtual IOReturn getInterruptType(int source, int *interruptType) override;
+    virtual IOReturn registerInterrupt(int source, OSObject *target, IOInterruptAction handler, void *refcon) override;
+    virtual IOReturn unregisterInterrupt(int source);
  protected:
  private:
     IOACPIPlatformDevice *acpi_device;
     bool get_device_resources();
+    
+    VoodooGPIO *gpioController;
+    VoodooGPIO *getGPIOController();
+    
+    bool hasGPIOInt;
+    
+    UInt16 gpioPin;
+    int gpioIRQ;
 };
 
 


### PR DESCRIPTION
Add support for interrupt handling on the device nub so the device drivers can just create an IOInterruptEventSource using the nub as a provider, abstracting APIC vs GPIO interrupts